### PR TITLE
Expanded service options added to Copyright widget

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,3 +16,6 @@ Company Repository for the Elementor Plugin Library that includes various widget
 
 ## Developer Documents
 The developer documents are currently being written and continusly added too. Once up to a good standard of documentation they will be available here.
+
+To ensure a new release is properly recognized by websites using this plugin, finalize your changes by updating the version in 's4l-plugin-library.php' on lines 6, 14 & 31.
+

--- a/s4l-plugin-library.php
+++ b/s4l-plugin-library.php
@@ -3,7 +3,7 @@
  * Plugin Name: Search4Local Widget library
  * Description: The official Search4Local widget library containing various widgets for use on sites.
  * Plugin URI: https://www.search4local.co.uk
- * Version: v1.1.1
+ * Version: v1.1.2
  * Author: Search4Local
  * Author URI: https://www.search4local.co.uk
  * Text Domain: s4l-plugin-library
@@ -11,7 +11,7 @@
 
 if( ! defined('ABSPATH') ) exit; // Exit if accessed directly
 
-define( 'S4L_PLUGIN_VERSION', '1.1.1' );
+define( 'S4L_PLUGIN_VERSION', '1.1.2' );
 define( 'S4L_PLUGIN__FILE__', __FILE__ );
 define( 'S4L_PLUGIN_BASE', plugin_basename( S4L_PLUGIN__FILE__ ) );
 define( 'S4L_PLUGIN_PATH',  plugin_dir_path( S4L_PLUGIN__FILE__ ));
@@ -28,7 +28,7 @@ define( 'S4l_PLUGIN_URL', plugins_url( '/', S4L_PLUGIN__FILE__ ) );
 		 * @since 1.0
 		 * @var string The plugin version.
 		 */
-		const VERSION = 'v1.1.1';
+		const VERSION = 'v1.1.2';
 		/**
 		 * Minimum Elementor Version
 		 *

--- a/widgets/copyright-text.php
+++ b/widgets/copyright-text.php
@@ -123,6 +123,7 @@ class Copyright_Text extends Widget_Base {
 			]
 		);
 
+
 		// Text control for Company Name
 		$this->add_control(
 			'company',
@@ -148,6 +149,38 @@ class Copyright_Text extends Widget_Base {
 				],
 				'placeholder' => __( 'Enter your title', 's4l-plugin-library' ),
 				'default' => __( 'Exeter', 's4l-plugin-library' ),
+			]
+		);
+
+		// Text control for Company Service
+		$this->add_control(
+			'service',
+			[
+				'label' => __( 'Company Service', 's4l-plugin-library' ),
+				'type' => Controls_Manager::TEXTAREA,
+				'dynamic' => [
+					'active' => true,
+				],
+				'placeholder' => __( 'Enter company service', 's4l-plugin-library' ),
+				'default' => __( 'Web Design', 's4l-plugin-library' ),
+			]
+		);
+
+		$this->add_control(
+			'service_link',
+			[
+				'label' => __( 'Service Link', 's4l-plugin-library' ),
+				'type' => \Elementor\Controls_Manager::URL,
+				'placeholder' => __( 'https://www.search4local.co.uk/', 's4l-plugin-library' ),
+				'show_external' => true,
+				'dynamic' => [
+					'active' => true,
+				],
+				'default' => [
+					'url' => '',
+					'is_external' => true,
+					'nofollow' => true,
+				],
 			]
 		);
 
@@ -191,8 +224,12 @@ class Copyright_Text extends Widget_Base {
 				<span <?php echo $this->get_render_attribute_string( 'company' ); ?>> <?php echo $settings['company']; ?></span>
 			</a>
 			-
-			<span class="all text" <?php echo $this->get_render_attribute_string( 'area' ); ?>> <?php echo $settings['area']; ?> Web Design</span>
+			<a href="<?php echo $settings['service_link']['url']?>" class="link text" style="color:<?php echo $settings['link_color']?>;">
+				<span <?php echo $this->get_render_attribute_string( 'area' ); ?>> <?php echo $settings['area']; ?> </span>
+				<span <?php echo $this->get_render_attribute_string( 'service' ); ?>> <?php echo $settings['service']; ?></span>
+			</a>
 			<span class="all text">by Search4Local</span>
+
 		</span>
 			<span id="policy-text">
 				<a href="/cookie-privacy-policy"  class="link text" style="color:<?php echo $settings['link_color']?>;">
@@ -233,7 +270,10 @@ class Copyright_Text extends Widget_Base {
 				<span class="all text" {{{ view.getRenderAttributeString( 'company' ) }}}>{{{ settings.company }}}</>
 			</a>
 			 -
-			<span class="all text" {{{ view.getRenderAttributeString( 'area' ) }}}>{{{ settings.area }}} Web Design</span>
+			<a href="{{ settings.service_link.url}}"  class="link" style="color:{{ settings.link_color}};text-decoration:none"></a>
+				<span class="all text" {{{ view.getRenderAttributeString( 'area' ) }}}>{{{ settings.area }}}</span>
+				<span class="all text" {{{ view.getRenderAttributeString( 'service' ) }}}> {{{ settings.service }}}</span>
+			</a>
 			<span class="all text">by Search4Local</span>
 			</span>
 


### PR DESCRIPTION
Added a few more controls to the Copyright widget, allowing user to type a 'Service'.

Wrapped service and area spans in a link so we can draw attention to particular pages of the S4L website from other websites of our choice.

Also added a little reminder to the readme for where to change the plugin version to ensure it can be updated properly within WordPress.