### PR TITLE
ACF Compatability and Bug Fixes

### DIFF
--- a/s4l-plugin-library.php
+++ b/s4l-plugin-library.php
@@ -3,7 +3,7 @@
  * Plugin Name: Search4Local Widget library
  * Description: The official Search4Local widget library containing various widgets for use on sites.
  * Plugin URI: https://www.search4local.co.uk
- * Version: v1.2.0
+ * Version: v1.2.2
  * Author: Search4Local
  * Author URI: https://www.search4local.co.uk
  * Text Domain: s4l-plugin-library
@@ -11,7 +11,7 @@
 
 if( ! defined('ABSPATH') ) exit; // Exit if accessed directly
 
-define( 'S4L_PLUGIN_VERSION', '1.2.0' );
+define( 'S4L_PLUGIN_VERSION', '1.2.2' );
 define( 'S4L_PLUGIN__FILE__', __FILE__ );
 define( 'S4L_PLUGIN_BASE', plugin_basename( S4L_PLUGIN__FILE__ ) );
 define( 'S4L_PLUGIN_PATH',  plugin_dir_path( S4L_PLUGIN__FILE__ ));
@@ -28,7 +28,7 @@ define( 'S4l_PLUGIN_URL', plugins_url( '/', S4L_PLUGIN__FILE__ ) );
 		 * @since 1.0
 		 * @var string The plugin version.
 		 */
-		const VERSION = 'v1.2.0';
+		const VERSION = 'v1.2.2';
 		/**
 		 * Minimum Elementor Version
 		 *

--- a/widgets/copyright-text.php
+++ b/widgets/copyright-text.php
@@ -52,7 +52,7 @@ class Copyright_Text extends Widget_Base {
 	 * @return string Widget icon.
 	 */
 	public function get_icon() {
-		return 'eicon-coding';
+		return 'eicon-info-circle';
 	}
 
 	/**
@@ -263,6 +263,7 @@ class Copyright_Text extends Widget_Base {
 		<#
 		view.addInlineEditingAttributes( 'company', 'none' );
 		view.addInlineEditingAttributes( 'area', 'none' );
+		view.addInlineEditingAttributes( 'service', 'none' );
 		#>
 		<span id="footer-copy" class="all text" style="color:{{ settings.text_color}};font-family:sans-serif;font-size:14px">
 			<span class="all text" id="company-text">
@@ -286,12 +287,7 @@ class Copyright_Text extends Widget_Base {
 					Sitemap
 				</a>
 			</span>
-			<p style="font-size:10px;font-weight:400;">© <span id="copy-date"></span> - Search4Local Ltd. The content of this website is owned by us and our client; copying of any content (including images) without our consent is in breach of our Terms & Conditions. | All rights Reserved</p>
-		<script>
-			var date = new Date().getFullYear();
-			let dateBoxes = document.querySelectorAll("#copy-date");
-			dateBoxes.forEach( box => { box.innerHTML = date });
-		</script>
+			<p style="font-size:10px;font-weight:400;">© <span id="copy-date"><?php echo date("Y"); ?></span> - Search4Local Ltd. The content of this website is owned by us and our client; copying of any content (including images) without our consent is in breach of our Terms & Conditions. | All rights Reserved</p>
 		</span>
 
 		<?php


### PR DESCRIPTION
Syntax error on editor initialization when 'ACF Frontend for Elementor' is also installed.
- Fixed by switching editor template date function from JS to PHP.

Updated versions properly, did not do this last fix release so plugin caught in update loop.

Icon associated with copyright widget no longer exists so I changed the icon code.